### PR TITLE
Allow caller to specify options to be passed to puppeteer.launch()

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "github",
-    "url": "https://github.com/lamartire/puppeteer-page-object"
+    "url": "https://github.com/joelstevick/puppeteer-page-object"
   },
   "keywords": [
     "puppeteer",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "github",
-    "url": "https://github.com/joelstevick/puppeteer-page-object"
+    "url": "https://github.com/lamartire/puppeteer-page-object"
   },
   "keywords": [
     "puppeteer",

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ class PageObject {
     this.headless = options.headless !== undefined ? options.headless : true
     this.scenarioName = options.scenarioName || ''
     this.args = options.args || ['--no-sandbox', '--disable-setuid-sandbox']
+    this.launchOptions = options.launchOptions || {}
 
     this.browser = null
     this.page = null
@@ -45,6 +46,7 @@ class PageObject {
    */
   async init() {
     this.browser = await puppeteer.launch({
+      ...this.launchOptions,
       headless: this.headless,
       args: this.args,
     })

--- a/src/index.js
+++ b/src/index.js
@@ -46,9 +46,9 @@ class PageObject {
    */
   async init() {
     this.browser = await puppeteer.launch({
-      ...this.launchOptions,
       headless: this.headless,
       args: this.args,
+      ...this.launchOptions,
     })
 
     this.page = await this.browser.newPage()


### PR DESCRIPTION
Want to allow options to be defined in a config file that is read at runtime and then injected into the constructor.